### PR TITLE
Update event parameters to use EventParameterFlag.NOT_SPECIFIED as default value

### DIFF
--- a/event_system/Event.py
+++ b/event_system/Event.py
@@ -1,4 +1,5 @@
 from abc import ABC
+from enum import Enum
 
 
 class Event(ABC):
@@ -7,3 +8,7 @@ class Event(ABC):
     """
 
     pass
+
+
+class EventParameterFlag(Enum):
+    NOT_SPECIFIED = "NOT_SPECIFIED"

--- a/event_system/EventBus.py
+++ b/event_system/EventBus.py
@@ -2,7 +2,7 @@ import asyncio
 from collections.abc import Coroutine
 from typing import Any, Callable, TypeVar, Union
 
-from event_system import Event
+from event_system import Event, EventParameterFlag
 
 AnyEvent = TypeVar("AnyEvent", bound=Event)
 """
@@ -103,7 +103,7 @@ class EventBus:
         Creates a filter function for the given event instance.
 
         The returned function checks:
-          - If a field value in `event_filter` is None, it does not filter on that field.
+          - If a field value in `event_filter` is EventParameterFlag.NOT_SPECIFIED, it does not filter on that field.
           - If a field value is a type, the corresponding event's field must be an instance of that type.
           - Otherwise, the event's field must match the `event_filter` value exactly.
 
@@ -117,8 +117,8 @@ class EventBus:
 
         def filter_func(event: Event) -> bool:
             for field_name, filter_value in vars(event_filter).items():
-                # Skip fields explicitly set to None, meaning "ignore this field"
-                if filter_value is None:
+                # Skip fields explicitly set to EventParameterFlag.NOT_SPECIFIED, meaning "ignore this field"
+                if filter_value == EventParameterFlag.NOT_SPECIFIED:
                     continue
 
                 event_value = getattr(event, field_name, None)

--- a/event_system/events/Audio.py
+++ b/event_system/events/Audio.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from enum import Enum
 
-from event_system import Event
+from event_system import Event, EventParameterFlag
 
 
 class AudioType(Enum):
@@ -16,13 +16,13 @@ class AudioDirection(Enum):
 
 @dataclass
 class VolumeUpdatedEvent(Event):
-    volume: float | None = None
-    audio_type: AudioType | None = None
-    audio_direction: AudioDirection | None = None
+    volume: float | EventParameterFlag | None = EventParameterFlag.NOT_SPECIFIED
+    audio_type: AudioType | EventParameterFlag | None = EventParameterFlag.NOT_SPECIFIED
+    audio_direction: AudioDirection | EventParameterFlag | None = EventParameterFlag.NOT_SPECIFIED
 
 
 @dataclass
 class SpeakingStateUpdate(Event):
-    is_speaking: bool | None = None
-    audio_type: AudioType | None = None
-    audio_direction: AudioDirection | None = None
+    is_speaking: bool | EventParameterFlag | None = EventParameterFlag.NOT_SPECIFIED
+    audio_type: AudioType | EventParameterFlag | None = EventParameterFlag.NOT_SPECIFIED
+    audio_direction: AudioDirection | EventParameterFlag | None = EventParameterFlag.NOT_SPECIFIED

--- a/event_system/events/Discord.py
+++ b/event_system/events/Discord.py
@@ -13,7 +13,7 @@ from discord import (
     VoiceClient,
 )
 
-from event_system import Event
+from event_system import Event, EventParameterFlag
 
 PartialMessageableChannel = Union[
     TextChannel, VoiceChannel, StageChannel, Thread, DMChannel, PartialMessageable
@@ -23,7 +23,7 @@ MessageableChannel = Union[PartialMessageableChannel, GroupChannel]
 
 @dataclass
 class VoiceChannelConnectedEvent(Event):
-    voice_client: VoiceClient
+    voice_client: VoiceClient | EventParameterFlag | None = EventParameterFlag.NOT_SPECIFIED
 
 
 @dataclass
@@ -33,9 +33,9 @@ class VoiceChannelDisconnectedEvent(Event):
 
 @dataclass
 class TextChannelConnectedEvent(Event):
-    channel: MessageableChannel
+    channel: MessageableChannel | EventParameterFlag | None = EventParameterFlag.NOT_SPECIFIED
 
 
 @dataclass
 class BotReadyEvent(Event):
-    client: Client
+    client: Client | EventParameterFlag | None = EventParameterFlag.NOT_SPECIFIED

--- a/event_system/events/LLMOutput.py
+++ b/event_system/events/LLMOutput.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from event_system import Event
+from event_system import Event, EventParameterFlag
 
 from .Pipeline import SystemOutputType
 from .System import CommandType
@@ -25,7 +25,7 @@ class InvalidTagEvent(Event):
     tag (string): the malformed tag text, or none if no tag was provided
     """
 
-    tag: str
+    tag: str | EventParameterFlag | None = EventParameterFlag.NOT_SPECIFIED
 
 
 @dataclass
@@ -38,8 +38,8 @@ class InactiveOutputEvent(Event):
     output_target (SystemOutputType): the target output that was unavailable
     """
 
-    message: str
-    tag: SystemOutputType
+    message: str | EventParameterFlag | None = EventParameterFlag.NOT_SPECIFIED
+    tag: SystemOutputType | EventParameterFlag | None = EventParameterFlag.NOT_SPECIFIED
 
 
 @dataclass
@@ -52,4 +52,4 @@ class InactiveCommandEvent(Event):
     command (CommandType): the command that was unavailable
     """
 
-    command: CommandType
+    command: CommandType | EventParameterFlag | None = EventParameterFlag.NOT_SPECIFIED

--- a/event_system/events/Pipeline.py
+++ b/event_system/events/Pipeline.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Union
 
-from event_system import Event
+from event_system import Event, EventParameterFlag
 
 if TYPE_CHECKING:
     from pipesys import Pipe
@@ -14,8 +14,8 @@ class MessageEvent(Event):
     An event that pipes raise when they have a message to pass along.
     """
 
-    message: str | None = None
-    sender: Union['Pipe', type["Pipe"], None] = None
+    message: str | EventParameterFlag | None = EventParameterFlag.NOT_SPECIFIED
+    sender: Union['Pipe', type["Pipe"], EventParameterFlag | None] = EventParameterFlag.NOT_SPECIFIED
 
     def __str__(self) -> str:
         if self.message is None:
@@ -80,9 +80,9 @@ class UserInputEvent(MessageEvent):
     A class representing an event to be raised when the system receives input from a user.
     """
 
-    message: str | None = None
-    user_input_type: SystemInputType | None = None
-    user_name: str | None = None
+    message: str | EventParameterFlag | None = EventParameterFlag.NOT_SPECIFIED
+    user_input_type: SystemInputType | EventParameterFlag | None = EventParameterFlag.NOT_SPECIFIED
+    user_name: str | EventParameterFlag | None = EventParameterFlag.NOT_SPECIFIED
     priority: int = 0
 
     def __str__(self) -> str:
@@ -107,7 +107,7 @@ class OutputRoutingEvent(MessageEvent):
     A dataclass representing an event to be raised to deliver output to a specific destination.
     """
 
-    destination: SystemOutputType = SystemOutputType.CONSOLE
+    destination: SystemOutputType | EventParameterFlag | None = EventParameterFlag.NOT_SPECIFIED
 
 
 @dataclass
@@ -123,8 +123,8 @@ class OutputAvailabilityEvent(Event):
     A dataclass representing an event to be raised when the system's outputs or commands change availability.
     """
 
-    output_type: SystemOutputType
-    output_available: bool
+    output_type: SystemOutputType | EventParameterFlag | None = EventParameterFlag.NOT_SPECIFIED
+    output_available: bool | EventParameterFlag | None = EventParameterFlag.NOT_SPECIFIED
 
 
 @dataclass
@@ -133,5 +133,5 @@ class InputActivityEvent(Event):
     A dataclass representing an event to be raised when the system's inputs change availability.
     """
 
-    input_type: SystemInputType
-    input_active: bool
+    input_type: SystemInputType | EventParameterFlag | None = EventParameterFlag.NOT_SPECIFIED
+    input_active: bool | EventParameterFlag | None = EventParameterFlag.NOT_SPECIFIED

--- a/event_system/events/System.py
+++ b/event_system/events/System.py
@@ -2,7 +2,7 @@ from asyncio import Task
 from dataclasses import dataclass
 from enum import Enum
 
-from event_system import Event
+from event_system import Event, EventParameterFlag
 
 
 class CommandType(Enum):
@@ -48,7 +48,7 @@ class CommandEvent(Event):
     A dataclass representing a system-wide command to be executed.
     """
 
-    command: CommandType
+    command: CommandType | EventParameterFlag | None = EventParameterFlag.NOT_SPECIFIED
 
 
 class StartupStage(Enum):
@@ -67,7 +67,7 @@ class StartupEvent(Event):
     A dataclass representing an event to be raised when the system is starting up.
     """
 
-    stage: StartupStage
+    stage: StartupStage | EventParameterFlag | None = EventParameterFlag.NOT_SPECIFIED
 
 
 @dataclass
@@ -80,8 +80,8 @@ class TaskCreatedEvent(Event):
     pretty_sender (str): a pretty string representation of the sender of the task
     """
 
-    task: Task
-    pretty_sender: str
+    task: Task | EventParameterFlag | None = EventParameterFlag.NOT_SPECIFIED
+    pretty_sender: str | EventParameterFlag | None = EventParameterFlag.NOT_SPECIFIED
 
 
 @dataclass
@@ -90,5 +90,5 @@ class CommandAvailabilityEvent(Event):
     A dataclass representing an event to be raised when the system's commands change availability.
     """
 
-    command_type: CommandType
-    command_available: bool
+    command_type: CommandType | EventParameterFlag | None = EventParameterFlag.NOT_SPECIFIED
+    command_available: bool | EventParameterFlag | None = EventParameterFlag.NOT_SPECIFIED


### PR DESCRIPTION
Fixes #1

Add `NOT_SPECIFIED` enum to `event_system/Event.py` to improve readability and allow specifying None as a parameter value in events.

Update `_create_filter_func` method in `event_system/EventBus.py` to check for `NOT_SPECIFIED` instead of `None`.

Update event classes in `event_system/events/Audio.py`, `event_system/events/Discord.py`, `event_system/events/LLMOutput.py`, `event_system/events/Pipeline.py`, and `event_system/events/System.py` to use `NOT_SPECIFIED` as the default value for their parameters.

Update type hints for event parameters in `event_system/events/Audio.py`, `event_system/events/Discord.py`, `event_system/events/LLMOutput.py`, `event_system/events/Pipeline.py`, and `event_system/events/System.py` to include `EventParameterFlag`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/beau101023/Nyako-System/pull/3?shareId=0fcc0dc3-628f-4698-8693-bc6fb1ba8976).