### PR TITLE
Add EventBus pytest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ qasync==0.27.1
 setuptools==65.5.0
 torch==2.1.0+cu121
 whisper_at==0.5
+pytest==8.2.0

--- a/tests/test_eventbus.py
+++ b/tests/test_eventbus.py
@@ -1,0 +1,27 @@
+import asyncio
+
+from event_system.EventBus import EventBus
+from event_system.events.System import CommandEvent, CommandType
+
+
+def test_eventbus_filtering():
+    bus = EventBus()
+    calls: list[CommandEvent] = []
+
+    def handler(event: CommandEvent):
+        calls.append(event)
+
+    # Subscribe to only STOP commands
+    bus.subscribe(CommandEvent(CommandType.STOP), handler)
+
+    # Publish non-matching events
+    asyncio.run(bus.publish(CommandEvent(CommandType.LISTEN)))
+    asyncio.run(bus.publish(CommandEvent(CommandType.SLEEP)))
+
+    assert calls == []
+
+    # Publish matching event
+    asyncio.run(bus.publish(CommandEvent(CommandType.STOP)))
+
+    assert len(calls) == 1
+    assert calls[0].command is CommandType.STOP


### PR DESCRIPTION
## Summary
- create basic pytest structure
- add EventBus filtering unit test
- include pytest in requirements

## Testing
- `pytest -q`
- `ruff check tests/test_eventbus.py`
- `ruff check . | head -n 20` (fails: Import block is un-sorted or un-formatted)

------
https://chatgpt.com/codex/tasks/task_e_6841b6fc87f083248534c818351bb285