### PR TITLE
Fix divide by zero in audio playback

### DIFF
--- a/audio_playback.py
+++ b/audio_playback.py
@@ -92,8 +92,10 @@ def audio_reformat(input_data: Tensor | np.ndarray | bytes, volume: float = 1.0)
             f"Input must be a tensor, numpy array, or bytes. Type is {type(input_data)}"
         )
 
-    # Normalize audio
-    audio_np = audio_np / np.max(audio_np)
+    # Normalize audio, but avoid divide-by-zero when the array is all zeros
+    max_val = np.max(audio_np)
+    if max_val != 0:
+        audio_np = audio_np / max_val
 
     # Apply volume
     audio_np = audio_np * volume


### PR DESCRIPTION
## Summary
- prevent divide-by-zero when normalizing audio in `audio_reformat`

## Testing
- `ruff check .` *(fails: found 50 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841b6f423788324bd660fbeba2e20ed