### PR TITLE
Fix spelling in docs

### DIFF
--- a/images/README.md
+++ b/images/README.md
@@ -1,6 +1,6 @@
 # Visual Output Image Directory
 
-Place PNG images here, named like "surprise.png", "happy.png", etc. When the VisualOutput LLM detects that the text it recieves is expressing the sentiments defined by the image names, it will display those images.
+Place PNG images here, named like "surprise.png", "happy.png", etc. When the VisualOutput LLM detects that the text it receives is expressing the sentiments defined by the image names, it will display those images.
 
 Example:
 LLM Output: "HI! I AM SO EXCITED!"

--- a/pipesys/outputs/DiscordVoiceOutput.py
+++ b/pipesys/outputs/DiscordVoiceOutput.py
@@ -20,7 +20,7 @@ from TTS import SileroTTS, TextToSpeech
 
 class DiscordVoiceOutput(Pipe):
     """
-    Module that recieves text input from a pipe, converts it to speech, and plays it on the discord voice channel the bot is currently connected to.
+    Module that receives text input from a pipe, converts it to speech, and plays it on the discord voice channel the bot is currently connected to.
     """
 
     text_to_speech: TextToSpeech


### PR DESCRIPTION
## Summary
- fix a typo in DiscordVoiceOutput docstring
- fix the same typo in images/README

## Testing
- `ruff check .` *(fails: import sorting and unused imports, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6841b6e4c0e48324b9217b50f27b1455